### PR TITLE
refactor(dispatcher): Automate handler registration using GCC/clang c…

### DIFF
--- a/dispatcher.h
+++ b/dispatcher.h
@@ -41,10 +41,23 @@ struct handler {
 };
 typedef struct handler handler;
 
+/* Auto-registration macro for GCC/Clang (runs before main) */
+#if defined(__GNUC__) || defined(__clang__)
+#define INSTALL_CHAIN(NAME) \
+  void install_##NAME##_chain() __attribute__((constructor)); \
+  void install_##NAME##_chain() \
+  { \
+    add_handler(NAME); \
+  }
+#else
+#define INSTALL_CHAIN(NAME)
+#endif
+
 #define START_HANDLER(NAME, METHOD, REGEX, RES, NUM, MATCHES) \
 void NAME##_func(); \
 handler NAME##_data = {NAME##_func, METHOD, REGEX, {0}, NUM, NULL}; \
 handler *NAME = &NAME##_data; \
+INSTALL_CHAIN(NAME); \
 void NAME##_func(regmatch_t MATCHES[]) { \
     response *int_response = response_empty(); \
     response *RES = int_response;

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -30,8 +30,12 @@ START_HANDLER (default_handler, GET, "", res, 0, matches) {
 } END_HANDLER
 
 int main() {
+#if defined(__GNUC__) || defined(__clang__)
+    // Handlers are auto-registered via constructor
+#else
     add_handler(simple);
     add_handler(default_handler);
+#endif
     serve_forever();
     return 0;
 }


### PR DESCRIPTION
…onstructor attribute

- Add INSTALL_CHAIN generic macro leveraging __attribute__((constructor)) to automatically call add_handler before main()
- Enhance START_HANDLER macro with auto-registration capability, eliminating manual initialization boilerplate
- Maintain backward compatibility - manual registration remains for non-GCC environments
- Update simple.c example to demonstrate new auto-registration flow

Key benefits:
1. Removes manual registration boilerplate code
2. Improves handler registration reliability (prevents missed registrations)
3. Only affects initialization logic - existing handler behavior unchanged